### PR TITLE
cut ps header output for correct postfix child count

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -485,7 +485,7 @@ function printServiceStatus()
         } else {
             $psExecCommand = "ps ax | grep $mta | grep -v grep | grep -v php";
             if ('postfix' === $mta) {
-                $psExecCommand = 'ps -U postfix -u postfix | grep -v MailScanner | grep -v "MailWatch SQL"';
+                $psExecCommand = 'ps -U postfix -u postfix | grep -v MailScanner | grep -v "MailWatch SQL" | grep -v PID';
             }
             exec($psExecCommand, $output);
             if (count($output) > 0) {


### PR DESCRIPTION
on linux systems (e.g. Ubuntu 22.04.1 LTS) ps command outputs a header line like this:
    PID TTY          TIME CMD
this should not be counted