### PR TITLE
display milter process count when 1

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -475,9 +475,12 @@ function printServiceStatus()
             exec('ps ax | grep MSMilter | grep -v grep', $output);
             if (count($output) > 0) {
                 $running = $yes;
-                $procs = count($output) - 1 . ' ' . __('children03');
             } else {
                 $running = $no;
+            }
+            if (count($output) > 1) {
+                $procs = count($output) - 1 . ' ' . __('children03');
+            } else {
                 $procs = count($output) . ' ' . __('procs03');
             }
             echo '    <tr><td>' . 'MSMilter' . __('colon99') . '</td>'


### PR DESCRIPTION
otherwise when mailscanner's "Milter Dispatcher = postfork" and the system idling, the status displays:
"MSMilter: YES | 0 children"